### PR TITLE
Fix tempfile error, Fix timestamp format

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,11 +6,11 @@ steps:
         "--build-arg",
         "PYTHON_VERSION=3.10.11",
         "-t",
-        "asia-southeast2-docker.pkg.dev/singa-423208/singa-backend/singa-predict-api:0.0.3",
+        "asia-southeast2-docker.pkg.dev/singa-423208/singa-backend/singa-predict-api:0.0.4",
         ".",
       ]
     env:
       - DOCKER_BUILDKIT=1
 
 images:
-  - "asia-southeast2-docker.pkg.dev/singa-423208/singa-backend/singa-predict-api:0.0.3"
+  - "asia-southeast2-docker.pkg.dev/singa-423208/singa-backend/singa-predict-api:0.0.4"

--- a/main.py
+++ b/main.py
@@ -32,8 +32,9 @@ def predict(video: UploadFile = File(
     media_type=["video/mp4", "video/x-m4v", "video/*"]
 )):
     try:
-        with tempfile.TemporaryFile() as tmp_file:
+        with tempfile.NamedTemporaryFile() as tmp_file:
             tmp_file.write(video.file.read())
+            # print(f"This is the temp file path: {tmp_file.name}")
             lm = load_model()
             result = lm.predict_v(tmp_file.name)
             tmp_file.close()

--- a/predict/predict.py
+++ b/predict/predict.py
@@ -10,14 +10,13 @@ from mediapipe.tasks import python  # type: ignore
 from mediapipe.tasks.python import vision  # type: ignore
 from mediapipe.framework.formats import landmark_pb2 # type: ignore
 
-
 from tensorflow.keras.models import Sequential  # type: ignore
 from tensorflow.keras.layers import BatchNormalization, Conv1D, MaxPooling1D, Flatten, Dense, Dropout, LSTM, TimeDistributed, Reshape, Bidirectional  # type: ignore
 from tensorflow.keras.callbacks import TensorBoard, EarlyStopping, ReduceLROnPlateau  # type: ignore
 from tensorflow.keras.regularizers import l2  # type: ignore
 from tensorflow.keras.optimizers import Adam # type: ignore
-
-from datetime import datetime
+# from tensorflow.config import list_physical_devices # type: ignore
+# from tensorflow.debugging import set_log_device_placement # type: ignore
 
 class LoadModel:
     def __init__(self, model_path: str):
@@ -360,6 +359,7 @@ class LoadModel:
 
             # Calculate timestamp based on frame rate
             timestamp_ms = int((time.time() - start_time) * 1000)
+            
 
             # Ensure timestamp is within video duration
             if timestamp_ms > duration * 1000:
@@ -427,7 +427,14 @@ class LoadModel:
                 #       consistent with recent actions, rather than a momentary anomaly.
                 if np.unique(predictions[-10:])[0] == np.argmax(result):
 
-                    current_time = time.strftime("%H:%M:%S", time.gmtime(time.time() - start_time))
+                    # current_time = time.strftime("%H:%M:%S.%f", time.gmtime(time.time() - start_time))
+
+                    elapsed_time = time.time() - start_time
+                    hours, remainder = divmod(int(elapsed_time), 3600)
+                    minutes, seconds = divmod(remainder, 60)
+                    milliseconds = int((elapsed_time - int(elapsed_time)) * 1000)
+
+                    current_time = f"{hours:02}:{minutes:02}:{seconds:02}.{milliseconds:03}"
 
                     # check if the confidence score of the current prediction index is above the threshold.
                     if result[np.argmax(result)] > self.threshold:


### PR DESCRIPTION
Tempfile with `TemporaryFile()` will not provide a unix-like path in a containerized environment. Change to `NamedTemporaryFile()`

Change timestamp format from `HH:MM:SS` to `HH:MM:SS.fff`